### PR TITLE
Adds requirements information

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
+gem 'sass', '~> 3.2.0'
 gem 'bootstrap-sass'
 gem 'compass'
-gem 'foreman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,15 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    bootstrap-sass (3.1.1.1)
+    bootstrap-sass (3.2.0.2)
       sass (~> 3.2)
-    chunky_png (1.2.6)
-    compass (0.12.2)
+    chunky_png (1.3.1)
+    compass (0.12.7)
       chunky_png (~> 1.2)
       fssm (>= 0.2.7)
-      sass (~> 3.1)
-    dotenv (0.7.0)
-    foreman (0.63.0)
-      dotenv (>= 0.7)
-      thor (>= 0.13.6)
-    fssm (0.2.9)
-    sass (3.3.7)
-    thor (0.18.1)
+      sass (~> 3.2.19)
+    fssm (0.2.10)
+    sass (3.2.19)
 
 PLATFORMS
   ruby
@@ -22,4 +17,4 @@ PLATFORMS
 DEPENDENCIES
   bootstrap-sass
   compass
-  foreman
+  sass (~> 3.2.0)

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,7 @@
 .. _quickref: http://docutils.sourceforge.net/docs/user/rst/quickref.html
 .. _reStructedText: http://docutils.sourceforge.net/rst.html
 .. _rest: reStructedText_
+.. _Homebrew: http://brew.sh/
 .. _`the repository`: https://github.com/Ceasar/Encyclopedia
 .. _`open a fresh issue`: https://github.com/Ceasar/Encyclopedia/issues
 
@@ -39,6 +40,53 @@ Features
 - Document search
 
 .. figure:: http://i.imgur.com/FXUUSNo.jpg
+
+Requirements
+================================================================================
+
+The short version:
+--------------------------------------------------------------------------------
+Make sure you have:
+
+- Python + virtualenv
+- Ruby + bundler and foreman gems
+- Node + npm
+
+Then just run ``make env`` and move on to Quickstart.
+
+The long version (for Mac OS X):
+--------------------------------------------------------------------------------
+
+- Install Homebrew_
+- Set up rbenv and install a version of Ruby:
+.. code:: bash
+
+  $ brew install rbenv
+  $ echo 'eval "$(rbenv init -)"' >> ~/.bashrc
+  $ source ~/.bashrc
+  $ brew install rbenv-gem-rehash
+  $ brew install ruby-build
+  $ rbenv install 2.1.2
+  $ rbenv global 2.1.2
+
+- Install bundler and foreman gems:
+.. code:: bash
+
+  $ gem install bundler foreman --no-rdoc --no-ri
+
+- Install Node (and thus npm):
+.. code:: bash
+
+  $ brew install node
+
+- Install Python and set up the virtualenv:
+.. code:: bash
+
+  $ brew install python
+  $ pip install virtualenv
+  $ make env
+
+To check if everything is set up correctly, go through Quickstart and try to ``make server``.
 
 Quickstart
 ================================================================================
@@ -78,7 +126,7 @@ Next, we'll create two reST_ source files: ``src/Python.rst`` and
 
     Python was created by Guido van Rossum in 1991.
 
-    
+
 ``src/Programming_language.rst`` should look like this::
 
     ********************************************************************************
@@ -158,9 +206,9 @@ Markdown) for a few reasons.
    "Title") inline link.``).
 
 3. It is more powerful than Markdown. Some important examples:
-   
+
    - Directives, (e.g. ``contents`` injects a table of contents)
-     
+
    - Multiple levels of section headers (Markdown supports only ``=`` and ``-``
      and then requires ``#`` prefixes, which are hard to read. reST provides any
      non-alphanumeric character. e.g. ``=-`:.'"~^_*+#``)


### PR DESCRIPTION
It should cover everything a fresh install needs to get Encyclopedia running.

Gemfile changes: I ran into an odd SASS issue on 3.3.x which was fixed by using 3.2.x. None of the dependents of sass need > 3.2.x, so I just added the version specification.

I removed foreman from the Gemfile on [this](https://github.com/ddollar/foreman) recommendation:

> Ruby users should take care not to install foreman in their project's Gemfile.
