### PR TITLE
Generate templates dynamically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ node_modules/
 src/
 app/static/images/
 app/static/stylesheets/
-templates/

--- a/Makefile
+++ b/Makefile
@@ -2,30 +2,17 @@
 
 ARCHFLAGS=-Wno-error=unused-command-line-argument-hard-error-in-future
 
-# Directory containing output files
-BUILD = app/templates/
 ENV=env
-# Files containing reStructuredText directives
-DIRECTIVES := $(wildcard config/*.rst)
 # Directory containing input files
 SRC = src
-# Options for compilation. By default, compiles with time stamps.
-RSTFLAGS = --time --report=none
 SASS_DIR = app/assets/sass/
 # Directory containing CSS files
 STYLESHEETS = app/static/stylesheets/
-# Names of files to build
-TARGETS := $(patsubst $(SRC)/%.rst,$(BUILD)%.html,$(wildcard $(SRC)/*.rst))
 
 
-all: $(TARGETS)
-
-$(BUILD):
-	mkdir -p $(BUILD)
-
-# Make the target file ($@) from the build file ($<)
-$(BUILD)%.html: $(SRC)/%.rst | $(BUILD) $(ENV) docutils.conf
-	. $(ENV)/bin/activate; cat $(DIRECTIVES) $< | rst2html.py $(RSTFLAGS) > '$@'
+server:
+	bundle install
+	foreman start
 
 $(ENV): requirements.txt
 	virtualenv $(ENV)
@@ -35,21 +22,11 @@ ifeq ($(OS_NAME),Darwin)
 endif
 	. $(ENV)/bin/activate; pip install -r requirements.txt
 
-node_modules:
-	npm install nodemon
-
 web: $(ENV)
 	. $(ENV)/bin/activate; python wsgi.py
 
-html: node_modules
-	node_modules/.bin/nodemon --exec "make --jobs=8" --watch $(SRC) --ext rst
-
 stylesheets:
 	compass watch --css-dir=$(STYLESHEETS) --sass-dir=$(SASS_DIR)
-
-server:
-	bundle install
-	foreman start
 	
 clean:
 	rm -r $(BUILD)

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,2 @@
 web: make web
-html: make html
 stylesheets: make stylesheets

--- a/app/models.py
+++ b/app/models.py
@@ -4,6 +4,9 @@ import unicodedata
 
 from whoosh.fields import Schema, ID, KEYWORD, STORED, TEXT
 
+from rst import rst_to_html
+from settings import DIRECTIVES, INDEX
+
 SCHEMA = Schema(
     content=TEXT(stored=True),
     tags=KEYWORD,
@@ -14,11 +17,10 @@ SCHEMA = Schema(
 
 class Document(object):
     """
-    A document consist of body or block-level elements, and may be structured
+    A document consists of body or block-level elements, and may be structured
     into sections.
-
     """
-    def __init__(self, title, time, tags=None):
+    def __init__(self, title, time=None, tags=None):
         self._title = title
         self.time = time
         self.tags = tags or []
@@ -35,6 +37,12 @@ class Document(object):
     @property
     def filename(self):
         return os.path.splitext(os.path.split(self.title)[-1])[0]
+
+    @property
+    def html(self):
+        with open(INDEX, 'rU') as index, open(DIRECTIVES, 'rU') as directives:
+            body = index.read() + directives.read() + self.content
+            return rst_to_html(body)
 
     def gen_elements(self):
         line_buffer = []

--- a/app/rst.py
+++ b/app/rst.py
@@ -1,5 +1,11 @@
+"""
+Utility functions for working with reStructuredText.
+"""
 import os
 import os.path
+
+from docutils import core
+from docutils.writers.html4css1 import Writer, HTMLTranslator
 
 
 def iteritems(filename):
@@ -24,3 +30,34 @@ def get_hyperlink_target(index, reference_name):
         return os.path.splitext(hyperlink_target)[0]
     else:
         return hyperlink_target
+
+
+def rst_to_html(rst_string, settings=None):
+    """Convert a string written in reStructuredText to an HTML string.
+
+    :param rst_string:
+        A string that holds the contents of a reStructuredText document.
+
+    :param settings:
+        Optional. A dictionary which overrides the default settings.
+
+        For a list of the possible keys and values, see
+        http://docutils.sourceforge.net/docs/user/config.html.
+
+        To log the values used, pass in ``'dump_settings': 'yes'``.
+    """
+    writer = Writer()
+    writer.translator_class = HTMLTranslator
+    if settings is None:
+        settings = {
+            # Include a time/datestamp in the document footer.
+            'datestamp': '%Y-%m-%d %H:%M UTC',
+            # Recognize and link to standalone PEP references (like "PEP 258").
+            'pep_references': 1,
+            # Do not report any system messages.
+            'report_level': 'none',
+            # Recognize and link to standalone RFC references (like "RFC 822").
+            'rfc_references': 1,
+        }
+    return core.publish_string(rst_string, writer=writer,
+                               settings_overrides=settings)

--- a/app/settings.py
+++ b/app/settings.py
@@ -1,0 +1,8 @@
+INDEX = "config/index.rst"
+INDEX_PATH = '.index'
+
+# Path to directives the user wants to include
+DIRECTIVES = "config/directives.rst"
+
+# Directory contain rst source files
+SRC = "src"


### PR DESCRIPTION
This patch makes it possible to generate HTML from rST programmatically (i.e. in Python), which eliminates the need to compile templates from the command line.

Closes #6 .
