### PR TITLE
Set up Travis CI integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,13 @@
 .env
 .index
 .sass-cache/
+.tox
+*.egg-info
 *.pyc
 
 config/index.rst
 env
+dist/
 node_modules/
 src/
 app/static/images/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python: 2.7
+env:
+  - TOX_ENV=py27
+install:
+  - pip install -r requirements.txt
+  - pip install tox
+script:
+  - tox -e $TOX_ENV

--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,9 @@
 Encyclopedia
 ================================================================================
 
+.. image:: https://travis-ci.org/Ceasar/Encyclopedia.svg
+    :target: https://travis-ci.org/Ceasar/Encyclopedia
+
 **Encyclopedia** is a tool that helps you write and maintain a private
 hypermedia encyclopedia.
 

--- a/app/models.py
+++ b/app/models.py
@@ -48,7 +48,7 @@ class Document(object):
     @property
     def datetime(self):
         """The date and time the document was modified."""
-        return datetime.datetime.fromtimestamp(self.time)
+        return datetime.datetime.utcfromtimestamp(self.time)
 
     @property
     def filename(self):
@@ -66,10 +66,20 @@ class Document(object):
         """
         The contents of the document rendered as HTML.
         """
-        with open(INDEX, 'rU') as index, open(DIRECTIVES, 'rU') as directives:
-            parts = [index.read(), directives.read(), self.content]
-            body = "".join(parts)
-            return rst_to_html(body)
+        parts = []
+        try:
+            with open(INDEX, 'rU') as index:
+                parts.append(index.read())
+        except IOError:
+            pass
+        try:
+            with open(DIRECTIVES, 'rU') as directives:
+                parts.append(directives.read())
+        except IOError:
+            pass
+        parts.append(self.content)
+        body = "".join(parts)
+        return rst_to_html(body)
 
     def gen_elements(self):
         line_buffer = []
@@ -96,6 +106,10 @@ class Document(object):
     @property
     def paragraphs(self):
         return list(self.gen_paragraphs())
+
+    @property
+    def html_paragraphs(self):
+        return list(rst_to_html(p) for p in self.gen_paragraphs())
 
     @property
     def reference_name(self):

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup
+
+setup(name="Encyclopedia",
+      version="0.1.0",
+      install_requires=[
+          "Flask",
+          "Whoosh",
+          "docutils",
+      ],
+    )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,7 +10,7 @@ def test_title():
 
 def test_datetime():
     doc = Document("Test", time=1411320556.0)
-    assert doc.datetime == datetime.datetime(2014, 9, 21, 10, 29, 16)
+    assert doc.datetime == datetime.datetime(2014, 9, 21, 17, 29, 16)
 
 
 def test_filename():

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py27
+
+[testenv]
+commands=py.test tests/
+deps=
+    pytest


### PR DESCRIPTION
This is failing right now because running `tox` is failing right now (which can be reproduced locally).

See: https://travis-ci.org/Ceasar/Encyclopedia/builds/37010267. Trace is copied below:

```
sing worker: worker-linux-4-2.bb.travis-ci.org:travis-linux-19
git.1
0.15s$ git clone --depth=50 --branch=travis git://github.com/Ceasar/Encyclopedia.git Ceasar/Encyclopedia
Cloning into 'Ceasar/Encyclopedia'...
remote: Counting objects: 291, done.
remote: Compressing objects: 100% (111/111), done.
remote: Total 291 (delta 137), reused 285 (delta 133)
Receiving objects: 100% (291/291), 159.24 KiB | 0 bytes/s, done.
Resolving deltas: 100% (137/137), done.
Checking connectivity... done.
$ cd Ceasar/Encyclopedia
git.4
$ git checkout -qf cc71ab582bea01c6719c636f904be5edc3d81cf1
couchdb stop/waiting
Setting environment variables from .travis.yml
$ export TOX_ENV=py27
0.01s$ source ~/virtualenv/python2.7/bin/activate
0.01s$ python --version
Python 2.7.8
0.30s$ pip --version
pip 1.5.4 from /home/travis/virtualenv/python2.7.8/lib/python2.7/site-packages (python 2.7)
install.1
9.57s$ pip install -r requirements.txt
Downloading/unpacking Flask==0.10.1 (from -r requirements.txt (line 1))
  Downloading Flask-0.10.1.tar.gz (544kB): 544kB downloaded
  Running setup.py (path:/home/travis/virtualenv/python2.7.8/build/Flask/setup.py) egg_info for package Flask

    warning: no files found matching '*' under directory 'tests'
    warning: no previously-included files matching '*.pyc' found under directory 'docs'
    warning: no previously-included files matching '*.pyo' found under directory 'docs'
    warning: no previously-included files matching '*.pyc' found under directory 'tests'
    warning: no previously-included files matching '*.pyo' found under directory 'tests'
    warning: no previously-included files matching '*.pyc' found under directory 'examples'
    warning: no previously-included files matching '*.pyo' found under directory 'examples'
    no previously-included directories found matching 'docs/_build'
    no previously-included directories found matching 'docs/_themes/.git'
Downloading/unpacking Whoosh==2.5.5 (from -r requirements.txt (line 2))
  Downloading Whoosh-2.5.5.tar.gz (964kB): 964kB downloaded
  Running setup.py (path:/home/travis/virtualenv/python2.7.8/build/Whoosh/setup.py) egg_info for package Whoosh

    warning: no files found matching '*.txt' under directory 'tests'
    warning: no files found matching '*.txt' under directory 'benchmark'
    warning: no files found matching '*.txt' under directory 'docs'
    warning: no files found matching '*.txt' under directory 'files'
    warning: no files found matching '*.py' under directory 'files'
    warning: no files found matching '*.jpg' under directory 'files'
Downloading/unpacking docutils==0.11 (from -r requirements.txt (line 3))
  Downloading docutils-0.11.tar.gz (1.6MB): 1.6MB downloaded
  Running setup.py (path:/home/travis/virtualenv/python2.7.8/build/docutils/setup.py) egg_info for package docutils

    warning: no files found matching 'MANIFEST'
    warning: no files found matching '*' under directory 'extras'
    warning: no previously-included files matching '.cvsignore' found under directory '*'
    warning: no previously-included files matching '*.pyc' found under directory '*'
    warning: no previously-included files matching '*~' found under directory '*'
    warning: no previously-included files matching '.DS_Store' found under directory '*'
Downloading/unpacking Werkzeug>=0.7 (from Flask==0.10.1->-r requirements.txt (line 1))
  Downloading Werkzeug-0.9.6.tar.gz (1.1MB): 1.1MB downloaded
  Running setup.py (path:/home/travis/virtualenv/python2.7.8/build/Werkzeug/setup.py) egg_info for package Werkzeug

    warning: no files found matching '*' under directory 'werkzeug/debug/templates'
    warning: no files found matching '*' under directory 'tests'
    warning: no previously-included files matching '*.pyc' found under directory 'docs'
    warning: no previously-included files matching '*.pyo' found under directory 'docs'
    warning: no previously-included files matching '*.pyc' found under directory 'tests'
    warning: no previously-included files matching '*.pyo' found under directory 'tests'
    warning: no previously-included files matching '*.pyc' found under directory 'examples'
    warning: no previously-included files matching '*.pyo' found under directory 'examples'
    no previously-included directories found matching 'docs/_build'
Downloading/unpacking Jinja2>=2.4 (from Flask==0.10.1->-r requirements.txt (line 1))
  Downloading Jinja2-2.7.3.tar.gz (378kB): 378kB downloaded
  Running setup.py (path:/home/travis/virtualenv/python2.7.8/build/Jinja2/setup.py) egg_info for package Jinja2

    warning: no files found matching '*' under directory 'custom_fixers'
    warning: no previously-included files matching '*' found under directory 'docs/_build'
    warning: no previously-included files matching '*.pyc' found under directory 'jinja2'
    warning: no previously-included files matching '*.pyc' found under directory 'docs'
    warning: no previously-included files matching '*.pyo' found under directory 'jinja2'
    warning: no previously-included files matching '*.pyo' found under directory 'docs'
Downloading/unpacking itsdangerous>=0.21 (from Flask==0.10.1->-r requirements.txt (line 1))
  Downloading itsdangerous-0.24.tar.gz (46kB): 46kB downloaded
  Running setup.py (path:/home/travis/virtualenv/python2.7.8/build/itsdangerous/setup.py) egg_info for package itsdangerous

    warning: no previously-included files matching '*' found under directory 'docs/_build'
Downloading/unpacking markupsafe (from Jinja2>=2.4->Flask==0.10.1->-r requirements.txt (line 1))
  Downloading MarkupSafe-0.23.tar.gz
  Running setup.py (path:/home/travis/virtualenv/python2.7.8/build/markupsafe/setup.py) egg_info for package markupsafe

Installing collected packages: Flask, Whoosh, docutils, Werkzeug, Jinja2, itsdangerous, markupsafe
  Running setup.py install for Flask

    warning: no files found matching '*' under directory 'tests'
    warning: no previously-included files matching '*.pyc' found under directory 'docs'
    warning: no previously-included files matching '*.pyo' found under directory 'docs'
    warning: no previously-included files matching '*.pyc' found under directory 'tests'
    warning: no previously-included files matching '*.pyo' found under directory 'tests'
    warning: no previously-included files matching '*.pyc' found under directory 'examples'
    warning: no previously-included files matching '*.pyo' found under directory 'examples'
    no previously-included directories found matching 'docs/_build'
    no previously-included directories found matching 'docs/_themes/.git'
  Running setup.py install for Whoosh

    warning: no files found matching '*.txt' under directory 'tests'
    warning: no files found matching '*.txt' under directory 'benchmark'
    warning: no files found matching '*.txt' under directory 'docs'
    warning: no files found matching '*.txt' under directory 'files'
    warning: no files found matching '*.py' under directory 'files'
    warning: no files found matching '*.jpg' under directory 'files'
  Running setup.py install for docutils
    changing mode of build/scripts-2.7/rst2html.py from 664 to 775
    changing mode of build/scripts-2.7/rst2s5.py from 664 to 775
    changing mode of build/scripts-2.7/rst2latex.py from 664 to 775
    changing mode of build/scripts-2.7/rst2xetex.py from 664 to 775
    changing mode of build/scripts-2.7/rst2man.py from 664 to 775
    changing mode of build/scripts-2.7/rst2xml.py from 664 to 775
    changing mode of build/scripts-2.7/rst2pseudoxml.py from 664 to 775
    changing mode of build/scripts-2.7/rstpep2html.py from 664 to 775
    changing mode of build/scripts-2.7/rst2odt.py from 664 to 775
    changing mode of build/scripts-2.7/rst2odt_prepstyles.py from 664 to 775

    warning: no files found matching 'MANIFEST'
    warning: no files found matching '*' under directory 'extras'
    warning: no previously-included files matching '.cvsignore' found under directory '*'
    warning: no previously-included files matching '*.pyc' found under directory '*'
    warning: no previously-included files matching '*~' found under directory '*'
    warning: no previously-included files matching '.DS_Store' found under directory '*'
    changing mode of /home/travis/virtualenv/python2.7.8/bin/rst2pseudoxml.py to 775
    changing mode of /home/travis/virtualenv/python2.7.8/bin/rst2html.py to 775
    changing mode of /home/travis/virtualenv/python2.7.8/bin/rst2s5.py to 775
    changing mode of /home/travis/virtualenv/python2.7.8/bin/rst2latex.py to 775
    changing mode of /home/travis/virtualenv/python2.7.8/bin/rst2xetex.py to 775
    changing mode of /home/travis/virtualenv/python2.7.8/bin/rst2xml.py to 775
    changing mode of /home/travis/virtualenv/python2.7.8/bin/rst2odt_prepstyles.py to 775
    changing mode of /home/travis/virtualenv/python2.7.8/bin/rst2odt.py to 775
    changing mode of /home/travis/virtualenv/python2.7.8/bin/rstpep2html.py to 775
    changing mode of /home/travis/virtualenv/python2.7.8/bin/rst2man.py to 775
  Running setup.py install for Werkzeug

    warning: no files found matching '*' under directory 'werkzeug/debug/templates'
    warning: no files found matching '*' under directory 'tests'
    warning: no previously-included files matching '*.pyc' found under directory 'docs'
    warning: no previously-included files matching '*.pyo' found under directory 'docs'
    warning: no previously-included files matching '*.pyc' found under directory 'tests'
    warning: no previously-included files matching '*.pyo' found under directory 'tests'
    warning: no previously-included files matching '*.pyc' found under directory 'examples'
    warning: no previously-included files matching '*.pyo' found under directory 'examples'
    no previously-included directories found matching 'docs/_build'
  Running setup.py install for Jinja2

    warning: no files found matching '*' under directory 'custom_fixers'
    warning: no previously-included files matching '*' found under directory 'docs/_build'
    warning: no previously-included files matching '*.pyc' found under directory 'jinja2'
    warning: no previously-included files matching '*.pyc' found under directory 'docs'
    warning: no previously-included files matching '*.pyo' found under directory 'jinja2'
    warning: no previously-included files matching '*.pyo' found under directory 'docs'
  Running setup.py install for itsdangerous

    warning: no previously-included files matching '*' found under directory 'docs/_build'
  Running setup.py install for markupsafe

    building 'markupsafe._speedups' extension
    gcc -pthread -fno-strict-aliasing -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I/opt/python/2.7.8/include/python2.7 -c markupsafe/_speedups.c -o build/temp.linux-x86_64-2.7/markupsafe/_speedups.o
    gcc -pthread -shared -L/opt/python/2.7.8/lib -Wl,-rpath=/opt/python/2.7.8/lib build/temp.linux-x86_64-2.7/markupsafe/_speedups.o -L/opt/python/2.7.8/lib -lpython2.7 -o build/lib.linux-x86_64-2.7/markupsafe/_speedups.so
Successfully installed Flask Whoosh docutils Werkzeug Jinja2 itsdangerous markupsafe
Cleaning up...
install.2
1.81s$ pip install tox
Downloading/unpacking tox
  Downloading tox-1.8.0.tar.gz (89kB): 89kB downloaded
  Running setup.py (path:/home/travis/virtualenv/python2.7.8/build/tox/setup.py) egg_info for package tox

Downloading/unpacking virtualenv>=1.11.2 (from tox)
  Downloading virtualenv-1.11.6-py2.py3-none-any.whl (1.6MB): 1.6MB downloaded
Requirement already satisfied (use --upgrade to upgrade): py>=1.4.17 in /home/travis/virtualenv/python2.7.8/lib/python2.7/site-packages (from tox)
Installing collected packages: tox, virtualenv
  Running setup.py install for tox

    Installing tox script to /home/travis/virtualenv/python2.7.8/bin
    Installing tox-quickstart script to /home/travis/virtualenv/python2.7.8/bin
Successfully installed tox virtualenv
Cleaning up...
6.79s$ tox -e $TOX_ENV
py27 create: /home/travis/build/Ceasar/Encyclopedia/.tox/py27
py27 installdeps: pytest
py27 runtests: PYTHONHASHSEED='1223815857'
py27 runtests: commands[0] | py.test -vv tests/
============================= test session starts ==============================
platform linux2 -- Python 2.7.8 -- py-1.4.25 -- pytest-2.6.3 -- /home/travis/build/Ceasar/Encyclopedia/.tox/py27/bin/python2.7
collected 0 items / 1 errors 
==================================== ERRORS ====================================
____________________ ERROR collecting tests/test_models.py _____________________
tests/test_models.py:3: in <module>
    from app.models import Corpus, Document
app/__init__.py:1: in <module>
    from flask import Flask
E   ImportError: No module named flask
=========================== 1 error in 0.03 seconds ============================
ERROR: InvocationError: '/home/travis/build/Ceasar/Encyclopedia/.tox/py27/bin/py.test -vv tests/'
___________________________________ summary ____________________________________
ERROR:   py27: commands failed
The command "tox -e $TOX_ENV" exited with 1.
Done. Your build exited with 1.
```
